### PR TITLE
fix familiar-cli version requirement in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,5 +33,5 @@ familiar invoke gemini refactor src/foo.py --save-skill --skill-name cleanup_ref
 
 ## requirements
 
-- [familiar-cli](https://github.com/cyberwitchery/familiar) >= 0.3.1
+- [familiar-cli](https://github.com/cyberwitchery/familiar) >= 0.4.0
 - [gemini cli](https://github.com/google/gemini-cli) installed and in path


### PR DESCRIPTION
The readme listed \`familiar-cli >= 0.3.1\` as a requirement, but \`pyproject.toml\` requires \`>= 0.4.0\` (since the 0.2.0 release added skill/subagent support which needs familiar-cli 0.4.0+).

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._