### PR TITLE
add unreleased changelog entry for readme version fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix `familiar-cli` version requirement in readme (was `>=0.3.1`, now `>=0.4.0`)
+
 ## 0.2.0 - 2026-02-16
 
 - add gemini skill and subagent path definitions for familiar `--save-skill` and `--save-subagent` support


### PR DESCRIPTION
## What

Adds a changelog entry under `## unreleased` noting the recent fix to the `familiar-cli` version requirement in the readme (was `>=0.3.1`, corrected to `>=0.4.0`).

## Why

The readme fix (ded6264) was merged but the changelog's unreleased section was left empty. This keeps the changelog up to date so the next release includes the note.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._